### PR TITLE
Add new run button to pipeline details

### DIFF
--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -46,6 +46,7 @@ const css = stylesheet({
 
 export enum QUERY_PARAMS {
   cloneFromRun = 'cloneFromRun',
+  pipelineFromRun = 'pipelineFromRun',
   experimentId = 'experimentId',
   isRecurring = 'recurring',
   firstRunInExperiment = 'firstRunInExperiment',

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -657,8 +657,8 @@ describe('NewRun', () => {
       await TestUtils.flushPromises();
 
       expect(updateBannerSpy).toHaveBeenCalledTimes(1);
-      expect(tree.state('clonedRunPipeline')).toEqual({ parameters: [] });
-      expect(tree.state('usePipelineFromClonedRun')).toBe(true);
+      expect(tree.state('pipelineFromRun')).toEqual({ parameters: [] });
+      expect(tree.state('usePipelineFromRun')).toBe(true);
     });
 
     it('shows switching controls when run has embedded pipeline, selects that pipeline by default,' +

--- a/frontend/src/pages/NewRun.test.tsx
+++ b/frontend/src/pages/NewRun.test.tsx
@@ -55,6 +55,7 @@ describe('NewRun', () => {
   const MOCK_EXPERIMENT = newMockExperiment();
   const MOCK_PIPELINE = newMockPipeline();
   const MOCK_RUN_DETAIL = newMockRunDetail();
+  const MOCK_RUN_WITH_EMBEDDED_PIPELINE = newMockRunWithEmbeddedPipeline();
 
   function newMockExperiment(): ApiExperiment {
     return {
@@ -86,6 +87,13 @@ describe('NewRun', () => {
     };
   }
 
+  function newMockRunWithEmbeddedPipeline(): ApiRunDetail {
+    const runDetail = newMockRunDetail();
+    delete runDetail.run!.pipeline_spec!.pipeline_id;
+    runDetail.run!.pipeline_spec!.workflow_manifest = '{"parameters": []}';
+    return runDetail;
+  }
+
   function generateProps(): PageProps {
     return {
       history: { push: historyPushSpy, replace: historyReplaceSpy } as any,
@@ -104,19 +112,7 @@ describe('NewRun', () => {
   }
 
   beforeEach(() => {
-    // Reset mocks
-    consoleErrorSpy.mockReset();
-    createJobSpy.mockReset();
-    createRunSpy.mockReset();
-    getExperimentSpy.mockReset();
-    getPipelineSpy.mockReset();
-    getRunSpy.mockReset();
-    historyPushSpy.mockReset();
-    historyReplaceSpy.mockReset();
-    updateBannerSpy.mockReset();
-    updateDialogSpy.mockReset();
-    updateSnackbarSpy.mockReset();
-    updateToolbarSpy.mockReset();
+    jest.clearAllMocks();
 
     consoleErrorSpy.mockImplementation(() => null);
     createRunSpy.mockImplementation(() => ({ id: 'new-run-id' }));
@@ -126,6 +122,7 @@ describe('NewRun', () => {
   });
 
   afterEach(() => {
+    jest.resetAllMocks();
     tree.unmount();
   });
 
@@ -390,6 +387,7 @@ describe('NewRun', () => {
       expect(tree.state('pipelineSelectorOpen')).toBe(false);
       await TestUtils.flushPromises();
     });
+  });
 
   describe('choosing an experiment', () => {
     it('opens up the experiment selector modal when users clicks \'Choose\'', async () => {
@@ -645,13 +643,10 @@ describe('NewRun', () => {
     });
 
     it('loads and selects embedded pipeline from run', async () => {
-      const runDetail = newMockRunDetail();
-      delete runDetail.run!.pipeline_spec!.pipeline_id;
-      runDetail.run!.pipeline_spec!.workflow_manifest = '{"parameters": []}';
       const props = generateProps();
-      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${MOCK_RUN_WITH_EMBEDDED_PIPELINE.run!.id}`;
 
-      getRunSpy.mockImplementation(() => runDetail);
+      getRunSpy.mockImplementation(() => MOCK_RUN_WITH_EMBEDDED_PIPELINE);
 
       tree = shallow(<TestNewRun {...props} />);
       await TestUtils.flushPromises();
@@ -663,13 +658,10 @@ describe('NewRun', () => {
 
     it('shows switching controls when run has embedded pipeline, selects that pipeline by default,' +
       ' and hides pipeline selector', async () => {
-        const runDetail = newMockRunDetail();
-        delete runDetail.run!.pipeline_spec!.pipeline_id;
-        runDetail.run!.pipeline_spec!.workflow_manifest = '{"parameters": []}';
         const props = generateProps();
-        props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
+        props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${MOCK_RUN_WITH_EMBEDDED_PIPELINE.run!.id}`;
 
-        getRunSpy.mockImplementation(() => runDetail);
+        getRunSpy.mockImplementation(() => MOCK_RUN_WITH_EMBEDDED_PIPELINE);
 
         tree = shallow(<TestNewRun {...props} />);
         await TestUtils.flushPromises();
@@ -677,13 +669,10 @@ describe('NewRun', () => {
       });
 
     it('shows pipeline selector when switching from embedded pipeline to select pipeline', async () => {
-      const runDetail = newMockRunDetail();
-      delete runDetail.run!.pipeline_spec!.pipeline_id;
-      runDetail.run!.pipeline_spec!.workflow_manifest = '{"parameters": []}';
       const props = generateProps();
-      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${MOCK_RUN_WITH_EMBEDDED_PIPELINE.run!.id}`;
 
-      getRunSpy.mockImplementation(() => runDetail);
+      getRunSpy.mockImplementation(() => MOCK_RUN_WITH_EMBEDDED_PIPELINE);
 
       tree = shallow(<TestNewRun {...props} />);
       await TestUtils.flushPromises();
@@ -692,13 +681,10 @@ describe('NewRun', () => {
     });
 
     it('resets selected pipeline from embedded when switching to select from pipeline list, and back', async () => {
-      const runDetail = newMockRunDetail();
-      delete runDetail.run!.pipeline_spec!.pipeline_id;
-      runDetail.run!.pipeline_spec!.workflow_manifest = '{"parameters": []}';
       const props = generateProps();
-      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${MOCK_RUN_WITH_EMBEDDED_PIPELINE.run!.id}`;
 
-      getRunSpy.mockImplementation(() => runDetail);
+      getRunSpy.mockImplementation(() => MOCK_RUN_WITH_EMBEDDED_PIPELINE);
 
       tree = shallow(<TestNewRun {...props} />);
       await TestUtils.flushPromises();
@@ -783,7 +769,103 @@ describe('NewRun', () => {
         mode: 'error',
       }));
     });
+  });
 
+  describe('arriving from pipeline details page', () => {
+
+    it('indicates that a pipeline is preselected and provides a means of selecting a different pipeline', async () => {
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.pipelineFromRun}=${MOCK_RUN_WITH_EMBEDDED_PIPELINE.run!.id}`;
+
+      getRunSpy.mockImplementationOnce(() => MOCK_RUN_WITH_EMBEDDED_PIPELINE);
+
+      tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(tree.state('usePipelineFromRun')).toBe(true);
+      expect(tree.state('usePipelineFromRunLabel')).toBe('Use pipeline from previous step');
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('retrieves the run with the embedded pipeline', async () => {
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.pipelineFromRun}=${MOCK_RUN_WITH_EMBEDDED_PIPELINE.run!.id}`;
+
+      getRunSpy.mockImplementationOnce(() => MOCK_RUN_WITH_EMBEDDED_PIPELINE);
+
+      tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(getRunSpy).toHaveBeenLastCalledWith(MOCK_RUN_WITH_EMBEDDED_PIPELINE.run!.id);
+    });
+
+    it('parses the embedded pipeline and stores it in state', async () => {
+      const runDetail = newMockRunWithEmbeddedPipeline();
+      runDetail.run!.pipeline_spec!.workflow_manifest = JSON.stringify(MOCK_PIPELINE);
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.pipelineFromRun}=${runDetail.run!.id}`;
+
+      getRunSpy.mockImplementationOnce(() => runDetail);
+
+      tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(tree.state('pipeline')).toEqual(MOCK_PIPELINE);
+      expect(tree.state('pipelineFromRun')).toEqual(MOCK_PIPELINE);
+      expect(tree.state('pipelineName')).toEqual(MOCK_PIPELINE.name);
+    });
+
+    it('displays a page error if it fails to parse the embedded pipeline', async () => {
+      const runDetail = newMockRunWithEmbeddedPipeline();
+      runDetail.run!.pipeline_spec!.workflow_manifest = 'not JSON';
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.pipelineFromRun}=${runDetail.run!.id}`;
+
+      getRunSpy.mockImplementationOnce(() => runDetail);
+
+      tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+        additionalInfo: 'Unexpected token o in JSON at position 1',
+        message: 'Error: failed to parse the embedded pipeline\'s spec: not JSON. Click Details for more information.',
+        mode: 'error',
+      }));
+    });
+
+    it('displays a page error if ', async () => {
+      const runDetail = newMockRunWithEmbeddedPipeline();
+      // Remove workflow_manifest entirely
+      delete runDetail.run!.pipeline_spec!.workflow_manifest;
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.pipelineFromRun}=${runDetail.run!.id}`;
+
+      getRunSpy.mockImplementationOnce(() => runDetail);
+
+      tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+        message: `Error: somehow the run provided in the query params: ${runDetail.run!.id} had no embedded pipeline.`,
+        mode: 'error',
+      }));
+    });
+
+    it('displays a page error if it fails to retrieve the run containing the embedded pipeline', async () => {
+      const props = generateProps();
+      props.location.search = `?${QUERY_PARAMS.pipelineFromRun}=${MOCK_RUN_WITH_EMBEDDED_PIPELINE.run!.id}`;
+
+      TestUtils.makeErrorResponseOnce(getRunSpy, 'test - error!');
+
+      tree = shallow(<TestNewRun {...props as any} />);
+      await TestUtils.flushPromises();
+
+      expect(updateBannerSpy).toHaveBeenLastCalledWith(expect.objectContaining({
+        additionalInfo: 'test - error!',
+        message: `Error: failed to retrieve the specified run: ${MOCK_RUN_WITH_EMBEDDED_PIPELINE.run!.id}. Click Details for more information.`,
+        mode: 'error',
+      }));
+    });
   });
 
   describe('creating a new run', () => {
@@ -888,13 +970,10 @@ describe('NewRun', () => {
     });
 
     it('copies pipeline from run in the create API call when cloning a run with embedded pipeline', async () => {
-      const runDetail = newMockRunDetail();
-      delete runDetail.run!.pipeline_spec!.pipeline_id;
-      runDetail.run!.pipeline_spec!.workflow_manifest = '{"parameters": []}';
       const props = generateProps();
-      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${runDetail.run!.id}`;
+      props.location.search = `?${QUERY_PARAMS.cloneFromRun}=${MOCK_RUN_WITH_EMBEDDED_PIPELINE.run!.id}`;
 
-      getRunSpy.mockImplementation(() => runDetail);
+      getRunSpy.mockImplementation(() => MOCK_RUN_WITH_EMBEDDED_PIPELINE);
 
       tree = shallow(<TestNewRun {...props} />);
       await TestUtils.flushPromises();
@@ -1077,7 +1156,6 @@ describe('NewRun', () => {
         open: true,
       });
     });
-
   });
 
   describe('creating a new recurring run', () => {

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -45,7 +45,6 @@ import { commonCss, padding, color } from '../Css';
 import { logger, errorToMessage } from '../lib/Utils';
 
 interface NewRunState {
-  pipelineFromRun?: ApiPipeline;
   description: string;
   errorMessage: string;
   experiment?: ApiExperiment;
@@ -56,6 +55,11 @@ interface NewRunState {
   isRecurringRun: boolean;
   maxConcurrentRuns?: string;
   pipeline?: ApiPipeline;
+  // This represents a pipeline from a run that is being cloned, or if a user is creating a run from
+  // a pipeline was not uploaded to the system (as in the case of runs created from notebooks).
+  // By storing this here instead of in the 'pipeline' field, we won't lose it if the user selects a
+  // different pipeline.
+  pipelineFromRun?: ApiPipeline;
   // TODO: this is only here to properly display the name in the text field.
   // There is definitely a way to do this that doesn't necessitate this being in state.
   // Note: this cannot be undefined/optional or the label animation for the input field will not
@@ -343,9 +347,12 @@ class NewRun extends Page<{}, NewRunState> {
             });
           } catch (err) {
             await this.showPageError(
-              `Error: failed to parse the embedded pipeline's spec from run: ${embeddedPipelineRunId}`, err);
+              `Error: failed to parse the embedded pipeline's spec: ${embeddedPipelineSpec}.`, err);
             logger.error(`Failed to parse the embedded pipeline's spec from run: ${embeddedPipelineRunId}`, err);
           }
+        } else {
+          await this.showPageError(
+            `Error: somehow the run provided in the query params: ${embeddedPipelineRunId} had no embedded pipeline.`);
         }
       } catch (err) {
         await this.showPageError(

--- a/frontend/src/pages/PipelineDetails.test.tsx
+++ b/frontend/src/pages/PipelineDetails.test.tsx
@@ -280,12 +280,15 @@ describe('PipelineDetails', () => {
     expect(newExperimentBtn).toBeDefined();
   });
 
-  it('does not have any toolbar buttons if it has an embedded pipeline', async () => {
+  it('only has \'create run\' toolbar button if viewing an embedded pipeline', async () => {
     tree = shallow(<PipelineDetails {...generateProps(true)} />);
     await getTemplateSpy;
     await TestUtils.flushPromises();
     const instance = tree.instance() as PipelineDetails;
-    expect(instance.getInitialToolbarState().actions).toEqual([]);
+    expect(instance.getInitialToolbarState().actions).toHaveLength(1);
+    const createRunBtn =
+      instance.getInitialToolbarState().actions.find(b => b.title === 'Create run');
+    expect(createRunBtn).toBeDefined();
   });
 
   it('clicking new experiment button navigates to new experiment page', async () => {

--- a/frontend/src/pages/PipelineDetails.tsx
+++ b/frontend/src/pages/PipelineDetails.tsx
@@ -33,7 +33,7 @@ import { ApiPipeline, ApiGetTemplateResponse } from '../apis/pipeline';
 import { Apis } from '../lib/Apis';
 import { Page } from './Page';
 import { RoutePage, RouteParams, QUERY_PARAMS } from '../components/Router';
-import { ToolbarProps } from '../components/Toolbar';
+import { ToolbarProps, ToolbarActionConfig } from '../components/Toolbar';
 import { URLParser } from '../lib/URLParser';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
 import { Workflow } from '../../third_party/argo-ui/argo_template';
@@ -49,7 +49,7 @@ interface PipelineDetailsState {
   selectedTab: number;
   summaryShown: boolean;
   template?: Workflow;
-  templateYaml?: string;
+  templateString?: string;
 }
 
 const summaryCardWidth = 500;
@@ -114,36 +114,48 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
 
   public getInitialToolbarState(): ToolbarProps {
     const fromRunId = new URLParser(this.props).get(QUERY_PARAMS.fromRunId);
+    const actions: ToolbarActionConfig[] = [{
+      action: () => this._createNewRun(),
+      icon: AddIcon,
+      id: 'createNewRunBtn',
+      outlined: true,
+      primary: true,
+      title: 'Create run',
+      tooltip: 'Create a new run within this pipeline',
+    }];
+
     if (fromRunId) {
       return {
-        actions: [],
+        actions,
         breadcrumbs: [
           { displayName: fromRunId, href: RoutePage.RUN_DETAILS.replace(':' + RouteParams.runId, fromRunId) }
         ],
         pageTitle: 'Pipeline details',
       };
     } else {
+      // Add buttons for creating experiment and deleting pipeline
+      actions.push({
+        action: this._createNewExperiment.bind(this),
+        icon: AddIcon,
+        id: 'startNewExperimentBtn',
+        outlined: true,
+        title: 'Start an experiment',
+        tooltip: 'Create a new experiment beginning with this pipeline',
+      }, {
+        action: () => this.props.updateDialog({
+          buttons: [
+            { onClick: () => this._deleteDialogClosed(true), text: 'Delete' },
+            { onClick: () => this._deleteDialogClosed(false), text: 'Cancel' },
+          ],
+          onClose: () => this._deleteDialogClosed(false),
+          title: 'Delete this pipeline?',
+        }),
+        id: 'deleteBtn',
+        title: 'Delete',
+        tooltip: 'Delete this pipeline',
+      });
       return {
-        actions: [{
-          action: this._createNewExperiment.bind(this),
-          icon: AddIcon,
-          id: 'startNewExperimentBtn',
-          primary: true,
-          title: 'Start an experiment',
-          tooltip: 'Create a new experiment beginning with this pipeline',
-        }, {
-          action: () => this.props.updateDialog({
-            buttons: [
-              { onClick: () => this._deleteDialogClosed(true), text: 'Delete' },
-              { onClick: () => this._deleteDialogClosed(false), text: 'Cancel' },
-            ],
-            onClose: () => this._deleteDialogClosed(false),
-            title: 'Delete this pipeline?',
-          }),
-          id: 'deleteBtn',
-          title: 'Delete',
-          tooltip: 'Delete this pipeline',
-        }],
+        actions,
         breadcrumbs: [{ displayName: 'Pipelines', href: RoutePage.PIPELINES }],
         pageTitle: this.props.match.params[RouteParams.pipelineId],
       };
@@ -151,7 +163,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
   }
 
   public render(): JSX.Element {
-    const { pipeline, selectedNodeId, selectedTab, summaryShown, templateYaml } = this.state;
+    const { pipeline, selectedNodeId, selectedTab, summaryShown, templateString } = this.state;
 
     let selectedNodeInfo: StaticGraphParser.SelectedNodeInfo | null = null;
     if (this.state.graph && this.state.graph.node(selectedNodeId)) {
@@ -218,10 +230,10 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
               </div>}
               {!this.state.graph && <span style={{ margin: '40px auto' }}>No graph to show</span>}
             </div>}
-            {selectedTab === 1 && !!templateYaml &&
+            {selectedTab === 1 && !!templateString &&
               <div className={css.containerCss}>
                 <CodeMirror
-                  value={templateYaml || ''}
+                  value={templateString || ''}
                   editorDidMount={(editor) => editor.refresh()}
                   options={{
                     lineNumbers: true,
@@ -252,7 +264,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
     const fromRunId = new URLParser(this.props).get(QUERY_PARAMS.fromRunId);
 
     let pipeline: ApiPipeline | null = null;
-    let templateYaml = '';
+    let templateString = '';
     let template: Workflow | undefined;
     let breadcrumbs: Array<{ displayName: string, href: string }> = [];
     const toolbarActions = [...this.props.toolbarProps.actions];
@@ -262,7 +274,20 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
     if (fromRunId) {
       try {
         const runDetails = await Apis.runServiceApi.getRun(fromRunId);
-        templateYaml = RunUtils.getPipelineSpec(runDetails.run) || '';
+
+        // Convert the run's pipeline spec to YAML to be displayed as the pipeline's source.
+        try {
+          const pipelineSpec = JSON.parse(RunUtils.getPipelineSpec(runDetails.run) || '{}');
+          try {
+            templateString = JsYaml.safeDump(pipelineSpec);
+          } catch (err) {
+            await this.showPageError('Failed to convert pipeline spec to YAML.', err);
+            logger.error('Failed to convert pipeline spec YAML.', err);
+          }
+        } catch (err) {
+          await this.showPageError('Failed to parse pipeline spec JSON.', err);
+          logger.error('Failed to parse pipeline spec JSON.', err);
+        }
 
         const relatedExperimentId = RunUtils.getFirstExperimentReferenceId(runDetails.run);
         let experiment: ApiExperiment | undefined;
@@ -308,7 +333,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
 
       try {
         templateResponse = await Apis.pipelineServiceApi.getTemplate(pipelineId);
-        templateYaml = templateResponse.template || '';
+        templateString = templateResponse.template || '';
       } catch (err) {
         await this.showPageError('Cannot retrieve pipeline template.', err);
         logger.error('Cannot retrieve pipeline details.', err);
@@ -323,7 +348,7 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
 
     let g: dagre.graphlib.Graph | undefined;
     try {
-      template = JsYaml.safeLoad(templateYaml);
+      template = JsYaml.safeLoad(templateString);
       g = StaticGraphParser.createGraph(template!);
     } catch (err) {
       await this.showPageError('Error: failed to generate Pipeline graph.', err);
@@ -333,8 +358,25 @@ class PipelineDetails extends Page<{}, PipelineDetailsState> {
       graph: g,
       pipeline,
       template,
-      templateYaml,
+      templateString,
     });
+  }
+
+  private _createNewRun(): void {
+    let searchString = '';
+    const fromRunId = new URLParser(this.props).get(QUERY_PARAMS.fromRunId);
+
+    if (fromRunId) {
+      searchString = new URLParser(this.props).build(Object.assign(
+        { [QUERY_PARAMS.pipelineFromRun]: fromRunId }
+      ));
+    } else {
+      searchString = new URLParser(this.props).build(Object.assign(
+        { [QUERY_PARAMS.pipelineId]: this.state.pipeline!.id || '' }
+      ));
+    }
+
+    this.props.history.push(RoutePage.NEW_RUN + searchString);
   }
 
   private _createNewExperiment(): void {

--- a/frontend/src/pages/RunList.tsx
+++ b/frontend/src/pages/RunList.tsx
@@ -196,7 +196,7 @@ class RunList extends React.Component<RunListProps, RunListState> {
     return (
       <Link className={commonCss.link} onClick={(e) => e.stopPropagation()}
         to={url}>
-        {pipelineInfo.showLink ? 'View pipeline' : pipelineInfo.displayName}
+        {pipelineInfo.showLink ? '[View pipeline]' : pipelineInfo.displayName}
       </Link>
     );
   }

--- a/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/NewRun.test.tsx.snap
@@ -1,5 +1,373 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`NewRun arriving from pipeline details page indicates that a pipeline is preselected and provides a means of selecting a different pipeline 1`] = `
+<div
+  className="page"
+>
+  <div
+    className="scrollContainer"
+  >
+    <div
+      className="header"
+    >
+      Run details
+    </div>
+    <WithStyles(FormControlLabel)
+      checked={true}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Use pipeline from previous step"
+      onChange={[Function]}
+    />
+    <WithStyles(FormControlLabel)
+      checked={false}
+      control={
+        <WithStyles(Radio)
+          color="primary"
+        />
+      }
+      label="Select a pipeline from list"
+      onChange={[Function]}
+    />
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "pipelineSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "selectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <ResourceSelector
+          columns={
+            Array [
+              Object {
+                "flex": 1,
+                "label": "Pipeline name",
+                "sortKey": "name",
+              },
+              Object {
+                "flex": 1.5,
+                "label": "Description",
+              },
+              Object {
+                "flex": 1,
+                "label": "Uploaded on",
+                "sortKey": "created_at",
+              },
+            ]
+          }
+          emptyMessage="No pipelines found. Upload a pipeline and then try again."
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          initialSortColumn="created_at"
+          listApi={[Function]}
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?pipelineFromRun=some-mock-run-id",
+            }
+          }
+          match=""
+          selectionChanged={[Function]}
+          title="Choose a pipeline"
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+              ],
+              "pageTitle": "Start a new run",
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelPipelineSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="usePipelineBtn"
+          onClick={[Function]}
+        >
+          Use this pipeline
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <WithStyles(Dialog)
+      PaperProps={
+        Object {
+          "id": "experimentSelectorDialog",
+        }
+      }
+      classes={
+        Object {
+          "paper": "selectorDialog",
+        }
+      }
+      onClose={[Function]}
+      open={false}
+    >
+      <WithStyles(DialogContent)>
+        <ResourceSelector
+          columns={
+            Array [
+              Object {
+                "flex": 1,
+                "label": "Experiment name",
+                "sortKey": "name",
+              },
+              Object {
+                "flex": 1.5,
+                "label": "Description",
+              },
+              Object {
+                "flex": 1,
+                "label": "Created at",
+                "sortKey": "created_at",
+              },
+            ]
+          }
+          emptyMessage="No experiments found. Create an experiment and then try again."
+          history={
+            Object {
+              "push": [MockFunction],
+              "replace": [MockFunction],
+            }
+          }
+          initialSortColumn="created_at"
+          listApi={[Function]}
+          location={
+            Object {
+              "pathname": "/runs/new",
+              "search": "?pipelineFromRun=some-mock-run-id",
+            }
+          }
+          match=""
+          selectionChanged={[Function]}
+          title="Choose an experiment"
+          toolbarProps={
+            Object {
+              "actions": Array [],
+              "breadcrumbs": Array [
+                Object {
+                  "displayName": "Experiments",
+                  "href": "/experiments",
+                },
+              ],
+              "pageTitle": "Start a new run",
+            }
+          }
+          updateBanner={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {},
+                ],
+              ],
+            }
+          }
+          updateDialog={[MockFunction]}
+          updateSnackbar={[MockFunction]}
+          updateToolbar={
+            [MockFunction] {
+              "calls": Array [
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+                Array [
+                  Object {
+                    "actions": Array [],
+                    "breadcrumbs": Array [
+                      Object {
+                        "displayName": "Experiments",
+                        "href": "/experiments",
+                      },
+                    ],
+                    "pageTitle": "Start a new run",
+                  },
+                ],
+              ],
+            }
+          }
+        />
+      </WithStyles(DialogContent)>
+      <WithStyles(DialogActions)>
+        <WithStyles(Button)
+          color="secondary"
+          id="cancelExperimentSelectionBtn"
+          onClick={[Function]}
+        >
+          Cancel
+        </WithStyles(Button)>
+        <WithStyles(Button)
+          color="secondary"
+          disabled={true}
+          id="useExperimentBtn"
+          onClick={[Function]}
+        >
+          Use this experiment
+        </WithStyles(Button)>
+      </WithStyles(DialogActions)>
+    </WithStyles(Dialog)>
+    <Component
+      autoFocus={true}
+      label="Run name"
+      onChange={[Function]}
+      required={true}
+      value=""
+    />
+    <Component
+      label="Description (optional)"
+      multiline={true}
+      onChange={[Function]}
+      value=""
+    />
+    <div>
+      This run will be associated with the following experiment
+    </div>
+    <Component
+      InputProps={
+        Object {
+          "classes": Object {
+            "disabled": "nonEditableInput",
+          },
+          "endAdornment": <WithStyles(InputAdornment)
+            position="end"
+          >
+            <WithStyles(Button)
+              color="secondary"
+              id="chooseExperimentBtn"
+              onClick={[Function]}
+              style={
+                Object {
+                  "margin": 0,
+                  "padding": "3px 5px",
+                }
+              }
+            >
+              Choose
+            </WithStyles(Button)>
+          </WithStyles(InputAdornment)>,
+          "readOnly": true,
+        }
+      }
+      disabled={true}
+      label="Experiment"
+      required={true}
+      value=""
+    />
+    <div
+      className="header"
+    >
+      Run parameters
+    </div>
+    <div>
+      This pipeline has no parameters
+    </div>
+    <div
+      className="flex"
+    >
+      <BusyButton
+        busy={false}
+        className="buttonAction"
+        disabled={true}
+        id="createNewRunBtn"
+        onClick={[Function]}
+        title="Create"
+      />
+      <WithStyles(Button)
+        id="exitNewRunPageBtn"
+        onClick={[Function]}
+      >
+        Cancel
+      </WithStyles(Button)>
+      <div
+        style={
+          Object {
+            "color": "red",
+          }
+        }
+      >
+        Run name is required
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`NewRun changes the exit button's text if query params indicate this is the first run of an experiment 1`] = `
 <div
   className="page"
@@ -387,7 +755,7 @@ exports[`NewRun changes the exit button's text if query params indicate this is 
 </div>
 `;
 
-exports[`NewRun choosing a pipeline cloning from a run shows pipeline selector when switching from embedded pipeline to select pipeline 1`] = `
+exports[`NewRun cloning from a run shows pipeline selector when switching from embedded pipeline to select pipeline 1`] = `
 <div
   className="page"
 >
@@ -790,7 +1158,7 @@ exports[`NewRun choosing a pipeline cloning from a run shows pipeline selector w
 </div>
 `;
 
-exports[`NewRun choosing a pipeline cloning from a run shows switching controls when run has embedded pipeline, selects that pipeline by default, and hides pipeline selector 1`] = `
+exports[`NewRun cloning from a run shows switching controls when run has embedded pipeline, selects that pipeline by default, and hides pipeline selector 1`] = `
 <div
   className="page"
 >
@@ -1162,7 +1530,7 @@ exports[`NewRun choosing a pipeline cloning from a run shows switching controls 
 </div>
 `;
 
-exports[`NewRun choosing a pipeline creating a new recurring run includes additional trigger input fields if run will be recurring 1`] = `
+exports[`NewRun creating a new recurring run includes additional trigger input fields if run will be recurring 1`] = `
 <div
   className="page"
 >
@@ -1549,7 +1917,7 @@ exports[`NewRun choosing a pipeline creating a new recurring run includes additi
 </div>
 `;
 
-exports[`NewRun choosing a pipeline creating a new run copies pipeline from run in the create API call when cloning a run with embedded pipeline 1`] = `
+exports[`NewRun creating a new run copies pipeline from run in the create API call when cloning a run with embedded pipeline 1`] = `
 <div
   className="page"
 >
@@ -1955,7 +2323,7 @@ exports[`NewRun choosing a pipeline creating a new run copies pipeline from run 
 </div>
 `;
 
-exports[`NewRun choosing a pipeline creating a new run updates the pipeline in state when a user fills in its params 1`] = `
+exports[`NewRun creating a new run updates the pipeline in state when a user fills in its params 1`] = `
 <div
   className="page"
 >
@@ -2402,7 +2770,7 @@ exports[`NewRun choosing a pipeline creating a new run updates the pipeline in s
 </div>
 `;
 
-exports[`NewRun choosing a pipeline creating a new run updates the pipeline params as user selects different pipelines 1`] = `
+exports[`NewRun creating a new run updates the pipeline params as user selects different pipelines 1`] = `
 <div
   className="page"
 >
@@ -2789,7 +3157,7 @@ exports[`NewRun choosing a pipeline creating a new run updates the pipeline para
 </div>
 `;
 
-exports[`NewRun choosing a pipeline creating a new run updates the pipeline params as user selects different pipelines 2`] = `
+exports[`NewRun creating a new run updates the pipeline params as user selects different pipelines 2`] = `
 <div
   className="page"
 >
@@ -3212,7 +3580,7 @@ exports[`NewRun choosing a pipeline creating a new run updates the pipeline para
 </div>
 `;
 
-exports[`NewRun choosing a pipeline creating a new run updates the pipeline params as user selects different pipelines 3`] = `
+exports[`NewRun creating a new run updates the pipeline params as user selects different pipelines 3`] = `
 <div
   className="page"
 >

--- a/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
+++ b/frontend/src/pages/__snapshots__/RunList.test.tsx.snap
@@ -7140,7 +7140,7 @@ exports[`RunList shows "View pipeline" button if pipeline is embedded in run 1`]
     href="/pipelines/details/?fromRun=test-run-id"
     onClick={[Function]}
   >
-    View pipeline
+    [View pipeline]
   </a>
 </Link>
 `;


### PR DESCRIPTION
Users will now be able to create a run directly from the pipeline details page.

If the pipeline was a regularly uploaded pipeline, the new run page will show the normal pipeline picker with the relevant pipeline preselected.

If the pipeline was part of a run created in a notebook or from the CLI, the new run page will instead show radio buttons allowing the user to continue with the relevant pipeline, or select a different one. Users can also change their minds about this and use the radio buttons to reselect the original pipeline.
![image](https://user-images.githubusercontent.com/34456002/49756972-214c8600-fc70-11e8-97b9-d292e79da1f7.png)

Fixes #53 